### PR TITLE
Add HTTP SSE server and Docker Compose setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Example environment file for the mcp-redmine server
+
+# URL to your Redmine instance
+REDMINE_URL=https://your-redmine-instance.example.com/
+
+# API key with access to Redmine
+REDMINE_API_KEY=your-api-key
+
+# Optional instructions to include in the redmine_request tool description
+REDMINE_REQUEST_INSTRUCTIONS="These are test instructions"
+
+# Transport protocol for the MCP server (default is 'sse')
+MCP_TRANSPORT=sse
+
+# Port for the HTTP server (defaults to 8369 if not set)
+PORT=8369
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,7 @@ RUN pip install --upgrade pip \
     && pip install uv \
     && uv sync
 
+ENV PORT=8369
+EXPOSE 8369
+
 CMD ["uv", "run", "--directory", "/app", "-m", "mcp_redmine.server", "main"]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Uses httpx for API requests and integrates with the Redmine OpenAPI specificatio
 
 
 ## Usage with Claude Desktop
-### 1. Installation using `uv`
+### 1. Running locally using `uv`
 
 Ensure you have uv installed.
 ```bash
@@ -43,71 +43,59 @@ Install uv if you haven't already.
   powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
   ```
 
+Start the MCP server (ensure `REDMINE_URL` and `REDMINE_API_KEY` are set):
+```bash
+REDMINE_URL=https://your-redmine-instance.example.com \
+REDMINE_API_KEY=your-api-key \
+uv run -m mcp_redmine.server main
+```
+
 Add to your `claude_desktop_config.json`:
 ```json
   {
     "mcpServers": {
       "redmine": {
-        "command": "uvx",
-        "args": ["--from", "mcp-redmine==2025.09.03.141435", 
-                "--refresh-package", "mcp-redmine", "mcp-redmine"],
-        "env": {
-          "REDMINE_URL": "https://your-redmine-instance.example.com",
-          "REDMINE_API_KEY": "your-api-key",
-          "REDMINE_REQUEST_INSTRUCTIONS": "/path/to/instructions.md"
-        }
+        "url": "http://localhost:8369"
       }
     }
   }
 ```
 
-### 2. Installation using `docker`
+### 2. Running using `docker-compose`
 
-Ensure you have docker installed. 
+Ensure you have docker installed.
 ```bash
 docker --version
 ```
 
-Build docker image:
+Copy `.env.example` to `.env` and set your Redmine credentials (and optionally the port and request instructions):
 ```bash
-git clone git@github.com:runekaagaard/mcp-redmine.git
-cd mcp-redmine
-docker build -t mcp-redmine .
+cp .env.example .env
+edit .env
 ```
-Add to your `claude_desktop_config.json`:
-  ```json
+
+Build and start the container:
+```bash
+docker compose up --build
+```
+
+The server will be available at `http://localhost:${PORT:-8369}`. Add to your `claude_desktop_config.json`:
+```json
   {
     "mcpServers": {
       "redmine": {
-        "command": "docker",
-        "args":  [
-            "run",
-            "-i",
-            "--rm",
-            "-e", "REDMINE_URL",
-            "-e", "REDMINE_API_KEY",
-            "-e", "REDMINE_REQUEST_INSTRUCTIONS",
-            "-v", "/path/to/instructions.md:/app/INSTRUCTIONS.md",
-            "mcp-redmine"
-        ],
-        "env": {
-          "REDMINE_URL": "https://your-redmine-instance.example.com",
-          "REDMINE_API_KEY": "your-api-key",
-          "REDMINE_REQUEST_INSTRUCTIONS": "/app/INSTRUCTIONS.md"
-        }
+        "url": "http://localhost:8369"
       }
     }
   }
-  ```
+```
 
 ## Environment Variables
 
 - `REDMINE_URL`: URL of your Redmine instance (required)
 - `REDMINE_API_KEY`: Your Redmine API key (required, see below for how to get it)
-- `REDMINE_REQUEST_INSTRUCTIONS`: Path to a file containing additional instructions for the redmine_request tool (optional). I've found it works great to have the LLM generate that file after a session. ([example1](INSTRUCTIONS_EXAMPLE1.md) [example2](INSTRUCTIONS_EXAMPLE2.md))
-
-> **Note**: When running via Docker, the `REDMINE_REQUEST_INSTRUCTIONS` environment variable must point to a **path inside the container**, not a path on the host machine.  
-> Therefore, if you want to use a local file, you need to **mount it into the container** at the correct location.
+- `REDMINE_REQUEST_INSTRUCTIONS`: Optional text with additional instructions for the `redmine_request` tool. ([example1](INSTRUCTIONS_EXAMPLE1.md) [example2](INSTRUCTIONS_EXAMPLE2.md))
+- `PORT`: Port for the HTTP server when using SSE transport (default: 8369)
 
 
 ## Getting Your Redmine API Key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.8"
+
+services:
+  mcp-redmine:
+    build: .
+    ports:
+      - "${PORT:-8369}:${PORT:-8369}"
+    environment:
+      PORT: ${PORT:-8369}
+      REDMINE_URL: ${REDMINE_URL}
+      REDMINE_API_KEY: ${REDMINE_API_KEY}
+      REDMINE_REQUEST_INSTRUCTIONS: ${REDMINE_REQUEST_INSTRUCTIONS:-}

--- a/mcp_redmine/server.py
+++ b/mcp_redmine/server.py
@@ -15,13 +15,9 @@ with open(current_dir / 'redmine_openapi.yml') as f:
     SPEC = yaml.safe_load(f)
 
 # Constants from environment
-REDMINE_URL = os.environ['REDMINE_URL']
-REDMINE_API_KEY = os.environ['REDMINE_API_KEY']
-if "REDMINE_REQUEST_INSTRUCTIONS" in os.environ:
-    with open(os.environ["REDMINE_REQUEST_INSTRUCTIONS"]) as f:
-        REDMINE_REQUEST_INSTRUCTIONS = f.read()
-else:
-    REDMINE_REQUEST_INSTRUCTIONS = ""
+REDMINE_URL = os.environ["REDMINE_URL"]
+REDMINE_API_KEY = os.environ["REDMINE_API_KEY"]
+REDMINE_REQUEST_INSTRUCTIONS = os.environ.get("REDMINE_REQUEST_INSTRUCTIONS", "")
 
 
 # Core
@@ -185,7 +181,14 @@ def redmine_download(attachment_id: int, save_path: str, filename: str = None) -
 
 def main():
     """Main entry point for the mcp-redmine package."""
-    mcp.run()
+    # Use HTTP (SSE) transport by default so the server is reachable over the network.
+    # A different transport can be selected by setting MCP_TRANSPORT (e.g. 'stdio').
+    transport = os.environ.get("MCP_TRANSPORT", "sse")
+    port = int(os.environ.get("PORT", 8369))
+    if transport == "sse":
+        mcp.run(transport=transport, host="0.0.0.0", port=port)
+    else:
+        mcp.run(transport=transport)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Expose the Redmine MCP server over HTTP by default using SSE transport.
- Make the HTTP port configurable via `PORT` (default 8369) and document usage with `.env.example`.
- Provide Docker Compose configuration with environment variables for the HTTP port and optional `REDMINE_REQUEST_INSTRUCTIONS` text.

## Testing
- `python -m py_compile mcp_redmine/server.py`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c52109fc4c8328a70acd95c4ee128a