### PR TITLE
Fix FastMCP run host/port parameters

### DIFF
--- a/mcp_redmine/server.py
+++ b/mcp_redmine/server.py
@@ -186,9 +186,9 @@ def main():
     transport = os.environ.get("MCP_TRANSPORT", "sse")
     port = int(os.environ.get("PORT", 8369))
     if transport == "sse":
-        mcp.run(transport=transport, host="0.0.0.0", port=port)
-    else:
-        mcp.run(transport=transport)
+        mcp.settings.host = "0.0.0.0"
+        mcp.settings.port = port
+    mcp.run(transport=transport)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Configure host and port via `mcp.settings` before running the server

## Testing
- `python -m py_compile mcp_redmine/server.py`


------
https://chatgpt.com/codex/tasks/task_e_68c527a0a7b083288b02d10093ba47c6