### PR TITLE
fix: update SSE transport import

### DIFF
--- a/mcp_redmine/server.py
+++ b/mcp_redmine/server.py
@@ -76,7 +76,7 @@ class AuthenticatedFastMCP(FastMCP):
         from starlette.responses import PlainTextResponse
         from starlette.routing import Mount, Route
         import uvicorn
-        from mcp.transport.sse import SseServerTransport
+        from mcp.server.sse import SseServerTransport
 
         sse = SseServerTransport("/messages/")
 


### PR DESCRIPTION
## Summary
- fix module import path for SseServerTransport

## Testing
- `ruff check mcp_redmine/server.py` (fails: E401 Multiple imports on one line, E722 Do not use bare `except`)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c52ced62d8832886470492021ac962