### PR TITLE
[mcp-redmine] Support both SSE and HTTP streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,9 @@ REDMINE_API_KEY=your-api-key \
 uv run -m mcp_redmine.server main
 ```
 
-To use the HTTP Streamable transport instead of SSE, set `MCP_TRANSPORT=streamable-http`:
-
-```bash
-REDMINE_URL=https://your-redmine-instance.example.com \
-REDMINE_API_KEY=your-api-key \
-MCP_TRANSPORT=streamable-http \
-uv run -m mcp_redmine.server main
-```
-
-Then connect using an MCP client configured for HTTP Streamable at `http://localhost:8369/mcp`.
+The server exposes both Server-Sent Events at `/sse` and Streamable HTTP at `/mcp` by default.
+To restrict the server to a single transport, set `MCP_TRANSPORT=sse` or
+`MCP_TRANSPORT=streamable-http`.
 
 Add to your `claude_desktop_config.json`:
 ```json
@@ -86,7 +79,8 @@ cp .env.example .env
 edit .env
 ```
 
-To use the HTTP Streamable transport with Docker, add `MCP_TRANSPORT=streamable-http` to your `.env` file.
+By default the container supports both transports. To limit it to one, add
+`MCP_TRANSPORT=sse` or `MCP_TRANSPORT=streamable-http` to your `.env` file.
 
 Build and start the container:
 ```bash
@@ -110,7 +104,7 @@ The server will be available at `http://localhost:${PORT:-8369}`. Add to your `c
 - `REDMINE_API_KEY`: Your Redmine API key (required, see below for how to get it)
 - `REDMINE_REQUEST_INSTRUCTIONS`: Optional text with additional instructions for the `redmine_request` tool. ([example1](INSTRUCTIONS_EXAMPLE1.md) [example2](INSTRUCTIONS_EXAMPLE2.md))
 - `PORT`: Port for the HTTP server when using `sse` or `streamable-http` transport (default: 8369)
-- `MCP_TRANSPORT`: Transport protocol to use (`sse` by default; also supports `streamable-http` and `stdio`)
+- `MCP_TRANSPORT`: Transport protocol (`both` by default; also supports `sse`, `streamable-http`, and `stdio`)
 - `LOG_LEVEL`: Log level for server output (default: INFO)
 - `MCP_AUTH_METHOD`: Optional authentication method for clients connecting to this MCP server (`bearer` or `header`)
 - `MCP_AUTH_TOKEN`: Token value expected from clients when `MCP_AUTH_METHOD` is set

--- a/mcp_redmine/server.py
+++ b/mcp_redmine/server.py
@@ -69,8 +69,7 @@ def yd(obj):
 
 
 class AuthenticatedFastMCP(FastMCP):
-    async def run_sse_async(self, mount_path: str | None = None) -> None:
-        import uvicorn
+    def sse_app(self, mount_path: str | None = None):
         from starlette.middleware.base import BaseHTTPMiddleware
         from starlette.responses import PlainTextResponse
 
@@ -94,6 +93,13 @@ class AuthenticatedFastMCP(FastMCP):
                     return await call_next(request)
 
             app.add_middleware(_AuthMiddleware)
+
+        return app
+
+    async def run_sse_async(self, mount_path: str | None = None) -> None:
+        import uvicorn
+
+        app = self.sse_app(mount_path)
 
         config = uvicorn.Config(
             app,
@@ -130,6 +136,37 @@ class AuthenticatedFastMCP(FastMCP):
             app.add_middleware(_AuthMiddleware)
 
         return app
+
+    def sse_and_streamable_http_app(self, mount_path: str | None = None):
+        app = self.streamable_http_app()
+        sse_app = self.sse_app(mount_path)
+
+        # Merge routes
+        app.router.routes.extend(sse_app.routes)
+
+        # Merge middleware without duplicates
+        existing = {mw.cls for mw in app.user_middleware}
+        for mw in sse_app.user_middleware:
+            if mw.cls not in existing:
+                app.user_middleware.append(mw)
+                existing.add(mw.cls)
+        app.middleware_stack = app.build_middleware_stack()
+
+        return app
+
+    async def run_sse_and_streamable_http_async(self, mount_path: str | None = None) -> None:
+        import uvicorn
+
+        app = self.sse_and_streamable_http_app(mount_path)
+
+        config = uvicorn.Config(
+            app,
+            host=self.settings.host,
+            port=self.settings.port,
+            log_level=self.settings.log_level.lower(),
+        )
+        server = uvicorn.Server(config)
+        await server.serve()
 
 
 # Tools
@@ -253,14 +290,17 @@ def redmine_download(attachment_id: int, save_path: str, filename: str = None) -
 
 def main():
     """Main entry point for the mcp-redmine package."""
-    # Use HTTP (SSE) transport by default so the server is reachable over the network.
-    # A different transport can be selected by setting MCP_TRANSPORT (e.g. 'stdio').
-    transport = os.environ.get("MCP_TRANSPORT", "sse")
+    transport = os.environ.get("MCP_TRANSPORT", "both")
     port = int(os.environ.get("PORT", 8369))
-    if transport in {"sse", "streamable-http"}:
+    if transport in {"sse", "streamable-http", "both"}:
         mcp.settings.host = "0.0.0.0"
         mcp.settings.port = port
-    mcp.run(transport=transport)
+    if transport == "both":
+        import asyncio
+
+        asyncio.run(mcp.run_sse_and_streamable_http_async())
+    else:
+        mcp.run(transport=transport)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- serve SSE and Streamable HTTP endpoints at the same time
- document default `MCP_TRANSPORT=both`

## Testing
- `REDMINE_URL=http://example.com REDMINE_API_KEY=dummy timeout 5 uv run -m mcp_redmine.server main`
- `curl -i http://localhost:8369/sse`
- `curl -i -X POST http://localhost:8369/mcp -d ''`


------
https://chatgpt.com/codex/tasks/task_e_68c57445a49c8328a03503a7c48b3712