### PR TITLE
[mcp-redmine] enhance info logging format

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The server will be available at `http://localhost:${PORT:-8369}`. Add to your `c
 - `REDMINE_API_KEY`: Your Redmine API key (required, see below for how to get it)
 - `REDMINE_REQUEST_INSTRUCTIONS`: Optional text with additional instructions for the `redmine_request` tool. ([example1](INSTRUCTIONS_EXAMPLE1.md) [example2](INSTRUCTIONS_EXAMPLE2.md))
 - `PORT`: Port for the HTTP server (default: 8369)
-- `LOG_LEVEL`: Log level for server output (default: INFO)
+- `LOG_LEVEL`: Log level for server output (default: INFO). Logs include timestamp, logger name, and source line when set to INFO or higher.
 - `MCP_AUTH_METHOD`: Optional authentication method for clients connecting to this MCP server (`bearer` or `header`)
 - `MCP_AUTH_TOKEN`: Token value expected from clients when `MCP_AUTH_METHOD` is set
 - `MCP_AUTH_HEADER`: Header name to check when using `MCP_AUTH_METHOD=header` (default: `X-MCP-Auth`)

--- a/mcp_redmine/server.py
+++ b/mcp_redmine/server.py
@@ -1,9 +1,9 @@
 import os, yaml, pathlib
 from urllib.parse import urljoin
 
+import logging
 import httpx
 from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.utilities.logging import get_logger, configure_logging
 
 ### Constants ###
 
@@ -20,7 +20,11 @@ REDMINE_API_KEY = os.environ["REDMINE_API_KEY"]
 REDMINE_REQUEST_INSTRUCTIONS = os.environ.get("REDMINE_REQUEST_INSTRUCTIONS", "")
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
 
-configure_logging(level=LOG_LEVEL)
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format="%(asctime)s | %(levelname)s | %(name)s | %(module)s:%(lineno)d | %(message)s",
+)
+logger = logging.getLogger(__name__)
 
 # Optional authentication for connecting to this MCP server
 MCP_AUTH_METHOD = os.environ.get("MCP_AUTH_METHOD")
@@ -99,7 +103,7 @@ class AuthenticatedFastMCP(FastMCP):
 
 # Tools
 mcp = AuthenticatedFastMCP("Redmine MCP server")
-get_logger(__name__).info(f"Starting MCP Redmine version {VERSION}")
+logger.info(f"Starting MCP Redmine version {VERSION}")
 
 @mcp.tool(description="""
 Make a request to the Redmine API


### PR DESCRIPTION
## Summary
- add detailed logging configuration for info level
- document enhanced log details

## Testing
- `uv run pytest`
- `REDMINE_URL=http://example.com REDMINE_API_KEY=dummy uv run -m mcp_redmine.server main`

------
https://chatgpt.com/codex/tasks/task_e_68c57b78b2a483289492ab58eb2a9d89