### PR TITLE
[mcp-redmine] Handle base64 request instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,9 +6,9 @@ REDMINE_URL=https://your-redmine-instance.example.com/
 # API key with access to Redmine
 REDMINE_API_KEY=your-api-key
 
-# Optional instructions to include in the redmine_request tool description
-# Use \n for line breaks in the instructions
-REDMINE_REQUEST_INSTRUCTIONS="Always return YAML\nUse terse descriptions"
+# Optional instructions to include in the redmine_request tool description (Base64 encoded)
+# Example: `printf 'Always return YAML\nUse terse descriptions' | base64 -w0`
+REDMINE_REQUEST_INSTRUCTIONS=QWx3YXlzIHJldHVybiBZQU1MClVzZSB0ZXJzZSBkZXNjcmlwdGlvbnM=
 
 # Optional authentication for clients connecting to the MCP server
 # Set MCP_AUTH_METHOD to 'bearer' or 'header' to require authentication,

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Ensure you have docker installed.
 docker --version
 ```
 
-Copy `.env.example` to `.env` and set your Redmine credentials (and optionally the port, log level and request instructions):
+Copy `.env.example` to `.env` and set your Redmine credentials (and optionally the port, log level and base64-encoded request instructions):
 
 ```bash
 cp .env.example .env
@@ -97,7 +97,7 @@ The server will be available at `http://localhost:${PORT:-8369}`. Add to your `c
 
 - `REDMINE_URL`: URL of your Redmine instance (required)
 - `REDMINE_API_KEY`: Your Redmine API key (required, see below for how to get it)
-- `REDMINE_REQUEST_INSTRUCTIONS`: Optional Markdown text with additional instructions for the `redmine_request` tool. Use `\n` for line breaks.
+- `REDMINE_REQUEST_INSTRUCTIONS`: Base64-encoded Markdown text with additional instructions for the `redmine_request` tool (e.g., `printf 'Always return YAML\\nUse terse descriptions' | base64 -w0`).
 - `PORT`: Port for the HTTP server (default: 8369)
 - `LOG_LEVEL`: Log level for server output (default: INFO). Logs include timestamp, logger name, and source line when set to INFO or higher.
 - `MCP_AUTH_METHOD`: Optional authentication method for clients connecting to this MCP server (`bearer` or `header`)

--- a/mcp_redmine/server.py
+++ b/mcp_redmine/server.py
@@ -1,4 +1,4 @@
-import os, yaml, pathlib
+import os, yaml, pathlib, base64
 from urllib.parse import urljoin
 
 import logging
@@ -17,9 +17,11 @@ with open(current_dir / 'redmine_openapi.yml') as f:
 # Constants from environment
 REDMINE_URL = os.environ["REDMINE_URL"]
 REDMINE_API_KEY = os.environ["REDMINE_API_KEY"]
-REDMINE_REQUEST_INSTRUCTIONS = (
-    os.environ.get("REDMINE_REQUEST_INSTRUCTIONS", "").replace("\\n", "\n")
-)
+_rri_b64 = os.environ.get("REDMINE_REQUEST_INSTRUCTIONS", "")
+try:
+    REDMINE_REQUEST_INSTRUCTIONS = base64.b64decode(_rri_b64).decode()
+except Exception:
+    REDMINE_REQUEST_INSTRUCTIONS = _rri_b64
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
 
 logging.basicConfig(


### PR DESCRIPTION
## Summary
- Decode `REDMINE_REQUEST_INSTRUCTIONS` from base64 for tool description
- Document base64 encoding for request instructions and update sample env file

## Testing
- `REDMINE_URL=https://example.com REDMINE_API_KEY=123 REDMINE_REQUEST_INSTRUCTIONS=$(printf 'Test instructions' | base64 -w0) timeout 5 uv run -m mcp_redmine.server main`


------
https://chatgpt.com/codex/tasks/task_e_68c582ef602883288e21b7b014b4b401