### PR TITLE
[mcp-redmine] Align server factory with OpenAI MCP guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,19 @@ Uses httpx for API requests and integrates with the Redmine OpenAPI specificatio
 
 
 ## Usage with Claude Desktop
-### 1. Running locally using `uv`
+### 1. Running locally using the `mcp` CLI
+
+The official MCP CLI can start the server directly. Once your environment variables are in place you can run:
+
+```bash
+REDMINE_URL=https://your-redmine-instance.example.com \
+REDMINE_API_KEY=your-api-key \
+mcp dev mcp_redmine.server:create_server
+```
+
+This launches the server with the MCP Inspector so you can verify tool behaviour before connecting a client. To run without the inspector use `mcp run mcp_redmine.server:create_server`.
+
+### 2. Running locally using `uv`
 
 Ensure you have uv installed.
 ```bash
@@ -63,7 +75,7 @@ Add to your `claude_desktop_config.json`:
   }
 ```
 
-### 2. Running using `docker-compose`
+### 3. Running using `docker-compose`
 
 Ensure you have docker installed.
 ```bash

--- a/mcp_redmine/server.py
+++ b/mcp_redmine/server.py
@@ -1,8 +1,13 @@
-import os, yaml, pathlib, base64
+import base64
+import logging
+import os
+import pathlib
+from dataclasses import dataclass
+from typing import Optional
 from urllib.parse import urljoin
 
-import logging
 import httpx
+import yaml
 from mcp.server.fastmcp import FastMCP
 
 ### Constants ###
@@ -11,40 +16,88 @@ VERSION = "2025.09.03.141435"
 
 # Load OpenAPI spec
 current_dir = pathlib.Path(__file__).parent
-with open(current_dir / 'redmine_openapi.yml') as f:
+with open(current_dir / "redmine_openapi.yml") as f:
     SPEC = yaml.safe_load(f)
 
-# Constants from environment
-REDMINE_URL = os.environ["REDMINE_URL"]
-REDMINE_API_KEY = os.environ["REDMINE_API_KEY"]
-_rri_b64 = os.environ.get("REDMINE_REQUEST_INSTRUCTIONS", "")
-try:
-    REDMINE_REQUEST_INSTRUCTIONS = base64.b64decode(_rri_b64).decode()
-except Exception:
-    REDMINE_REQUEST_INSTRUCTIONS = _rri_b64
-LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
 
-logging.basicConfig(
-    level=getattr(logging, LOG_LEVEL, logging.INFO),
-    format="%(asctime)s | %(levelname)s | %(name)s | %(module)s:%(lineno)d | %(message)s",
-)
 logger = logging.getLogger(__name__)
 
-# Optional authentication for connecting to this MCP server
-MCP_AUTH_METHOD = os.environ.get("MCP_AUTH_METHOD")
-MCP_AUTH_TOKEN = os.environ.get("MCP_AUTH_TOKEN")
-MCP_AUTH_HEADER = os.environ.get("MCP_AUTH_HEADER", "X-MCP-Auth")
+
+@dataclass(slots=True)
+class RedmineSettings:
+    """Runtime configuration for the Redmine MCP server."""
+
+    url: str
+    api_key: str
+    port: int = 8369
+    log_level: str = "INFO"
+    request_instructions: str = ""
+    auth_method: Optional[str] = None
+    auth_token: Optional[str] = None
+    auth_header: str = "X-MCP-Auth"
+
+    @classmethod
+    def from_env(cls) -> "RedmineSettings":
+        """Load settings from environment variables following MCP guidance."""
+
+        missing = [name for name in ("REDMINE_URL", "REDMINE_API_KEY") if not os.getenv(name)]
+        if missing:
+            names = ", ".join(missing)
+            raise RuntimeError(
+                f"Missing required environment variables: {names}. "
+                "Set them before starting the Redmine MCP server."
+            )
+
+        instructions_raw = os.getenv("REDMINE_REQUEST_INSTRUCTIONS", "")
+        instructions = instructions_raw
+        if instructions_raw:
+            try:
+                instructions = base64.b64decode(instructions_raw).decode()
+            except Exception:
+                # Fall back to the provided value if decoding fails
+                instructions = instructions_raw
+
+        port_value = os.getenv("PORT")
+        try:
+            port = int(port_value) if port_value else 8369
+        except ValueError as exc:
+            raise RuntimeError(f"PORT must be an integer, got: {port_value!r}") from exc
+
+        return cls(
+            url=os.environ["REDMINE_URL"],
+            api_key=os.environ["REDMINE_API_KEY"],
+            port=port,
+            log_level=os.getenv("LOG_LEVEL", "INFO").upper(),
+            request_instructions=instructions,
+            auth_method=os.getenv("MCP_AUTH_METHOD"),
+            auth_token=os.getenv("MCP_AUTH_TOKEN"),
+            auth_header=os.getenv("MCP_AUTH_HEADER", "X-MCP-Auth"),
+        )
 
 
 # Core
-def request(path: str, method: str = 'get', data: dict = None, params: dict = None,
-            content_type: str = 'application/json', content: bytes = None) -> dict:
-    headers = {'X-Redmine-API-Key': REDMINE_API_KEY, 'Content-Type': content_type}
-    url = urljoin(REDMINE_URL, path.lstrip('/'))
+def request(
+    settings: RedmineSettings,
+    path: str,
+    method: str = "get",
+    data: dict | None = None,
+    params: dict | None = None,
+    content_type: str = "application/json",
+    content: bytes | None = None,
+) -> dict:
+    headers = {"X-Redmine-API-Key": settings.api_key, "Content-Type": content_type}
+    url = urljoin(settings.url, path.lstrip("/"))
 
     try:
-        response = httpx.request(method=method.lower(), url=url, json=data, params=params, headers=headers,
-                                 content=content, timeout=60.0)
+        response = httpx.request(
+            method=method.lower(),
+            url=url,
+            json=data,
+            params=params,
+            headers=headers,
+            content=content,
+            timeout=60.0,
+        )
         response.raise_for_status()
 
         body = None
@@ -77,26 +130,43 @@ def yd(obj):
 
 
 class AuthenticatedFastMCP(FastMCP):
+    def __init__(
+        self,
+        *args,
+        auth_method: Optional[str] = None,
+        auth_token: Optional[str] = None,
+        auth_header: str = "X-MCP-Auth",
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._auth_method = (auth_method or "").lower() or None
+        self._auth_token = auth_token
+        self._auth_header = auth_header
+
     def streamable_http_app(self):
         from starlette.middleware.base import BaseHTTPMiddleware
         from starlette.responses import PlainTextResponse
 
         app = super().streamable_http_app()
 
-        if MCP_AUTH_METHOD and MCP_AUTH_TOKEN:
+        auth_method = self._auth_method
+        auth_token = self._auth_token
+        auth_header_name = self._auth_header
+
+        if auth_method and auth_token:
             class _AuthMiddleware(BaseHTTPMiddleware):
                 async def dispatch(self, request, call_next):
-                    method = MCP_AUTH_METHOD.lower()
+                    method = auth_method
                     if method == "bearer":
-                        auth_header = request.headers.get("authorization")
-                        if not auth_header or not auth_header.startswith("Bearer "):
+                        authorization_header = request.headers.get("authorization")
+                        if not authorization_header or not authorization_header.startswith("Bearer "):
                             return PlainTextResponse("Unauthorized", status_code=401)
-                        token = auth_header.split(" ", 1)[1]
-                        if token != MCP_AUTH_TOKEN:
+                        token = authorization_header.split(" ", 1)[1]
+                        if token != auth_token:
                             return PlainTextResponse("Unauthorized", status_code=401)
                     elif method == "header":
-                        header_value = request.headers.get(MCP_AUTH_HEADER)
-                        if header_value != MCP_AUTH_TOKEN:
+                        header_value = request.headers.get(auth_header_name)
+                        if header_value != auth_token:
                             return PlainTextResponse("Unauthorized", status_code=401)
                     return await call_next(request)
 
@@ -105,130 +175,151 @@ class AuthenticatedFastMCP(FastMCP):
         return app
 
 
-# Tools
-mcp = AuthenticatedFastMCP("Redmine MCP server")
-logger.info(f"Starting MCP Redmine version {VERSION}")
+def create_server(settings: RedmineSettings | None = None) -> AuthenticatedFastMCP:
+    """Create and configure the MCP server following OpenAI guidelines."""
 
-@mcp.tool(description="""
-Make a request to the Redmine API
+    settings = settings or RedmineSettings.from_env()
 
-Args:
-    path: API endpoint path (e.g. '/issues.json')
-    method: HTTP method to use (default: 'get')
-    data: Dictionary for request body (for POST/PUT)
-    params: Dictionary for query parameters
+    logging.basicConfig(
+        level=getattr(logging, settings.log_level, logging.INFO),
+        format="%(asctime)s | %(levelname)s | %(name)s | %(module)s:%(lineno)d | %(message)s",
+    )
+    logger.setLevel(getattr(logging, settings.log_level, logging.INFO))
+    logger.info(f"Starting MCP Redmine version {VERSION}")
 
-Returns:
-    str: YAML string containing response status code, body and error message
+    mcp = AuthenticatedFastMCP(
+        "Redmine MCP server",
+        log_level=settings.log_level,
+        auth_method=settings.auth_method,
+        auth_token=settings.auth_token,
+        auth_header=settings.auth_header,
+    )
 
-{}""".format(REDMINE_REQUEST_INSTRUCTIONS).strip())
-    
-def redmine_request(path: str, method: str = 'get', data: dict = None, params: dict = None) -> str:
-    return yd(request(path, method=method, data=data, params=params))
+    request_description = (
+        """
+        Make a request to the Redmine API
 
-@mcp.tool()
-def redmine_paths_list() -> str:
-    """Return a list of available API paths from OpenAPI spec
-    
-    Retrieves all endpoint paths defined in the Redmine OpenAPI specification. Remember that you can use the
-    redmine_paths_info tool to get the full specfication for a path.
-    
-    Returns:
-        str: YAML string containing a list of path templates (e.g. '/issues.json')
-    """
-    return yd(list(SPEC['paths'].keys()))
+        Args:
+            path: API endpoint path (e.g. '/issues.json')
+            method: HTTP method to use (default: 'get')
+            data: Dictionary for request body (for POST/PUT)
+            params: Dictionary for query parameters
 
-@mcp.tool()
-def redmine_paths_info(path_templates: list) -> str:
-    """Get full path information for given path templates
-    
-    Args:
-        path_templates: List of path templates (e.g. ['/issues.json', '/projects.json'])
-        
-    Returns:
-        str: YAML string containing API specifications for the requested paths
-    """
-    info = {}
-    for path in path_templates:
-        if path in SPEC['paths']:
-            info[path] = SPEC['paths'][path]
+        Returns:
+            str: YAML string containing response status code, body and error message
 
-    return yd(info)
+        {}
+        """.format(settings.request_instructions)
+        .strip()
+    )
 
-@mcp.tool()
-def redmine_upload(file_path: str, description: str = None) -> str:
-    """
-    Upload a file to Redmine and get a token for attachment
-    
-    Args:
-        file_path: Fully qualified path to the file to upload
-        description: Optional description for the file
-        
-    Returns:
-        str: YAML string containing response status code, body and error message
-             The body contains the attachment token
-    """
-    try:
-        path = pathlib.Path(file_path).expanduser()
-        assert path.is_absolute(), f"Path must be fully qualified, got: {file_path}"
-        assert path.exists(), f"File does not exist: {file_path}"
+    @mcp.tool(description=request_description)
+    def redmine_request(
+        path: str,
+        method: str = "get",
+        data: dict | None = None,
+        params: dict | None = None,
+    ) -> str:
+        return yd(request(settings, path, method=method, data=data, params=params))
 
-        params = {'filename': path.name}
-        if description:
-            params['description'] = description
+    @mcp.tool()
+    def redmine_paths_list() -> str:
+        """Return a list of available API paths from OpenAPI spec"""
 
-        with open(path, 'rb') as f:
-            file_content = f.read()
+        return yd(list(SPEC["paths"].keys()))
 
-        result = request(path='uploads.json', method='post', params=params,
-                         content_type='application/octet-stream', content=file_content)
-        return yd(result)
-    except Exception as e:
-        return yd({"status_code": 0, "body": None, "error": f"{e.__class__.__name__}: {e}"})
+    @mcp.tool()
+    def redmine_paths_info(path_templates: list[str]) -> str:
+        """Get full path information for given path templates"""
 
-@mcp.tool()
-def redmine_download(attachment_id: int, save_path: str, filename: str = None) -> str:
-    """
-    Download an attachment from Redmine and save it to a local file
-    
-    Args:
-        attachment_id: The ID of the attachment to download
-        save_path: Fully qualified path where the file should be saved to
-        filename: Optional filename to use for the attachment. If not provided, 
-                 will be determined from attachment data or URL
-        
-    Returns:
-        str: YAML string containing download status, file path, and any error messages
-    """
-    try:
-        path = pathlib.Path(save_path).expanduser()
-        assert path.is_absolute(), f"Path must be fully qualified, got: {save_path}"
-        assert not path.is_dir(), f"Path can't be a directory, got: {save_path}"
+        info = {}
+        for path in path_templates:
+            if path in SPEC["paths"]:
+                info[path] = SPEC["paths"][path]
 
-        if not filename:
-            attachment_response = request(f"attachments/{attachment_id}.json", "get")
-            if attachment_response["status_code"] != 200:
-                return yd(attachment_response)
+        return yd(info)
 
-            filename = attachment_response["body"]["attachment"]["filename"]
+    @mcp.tool()
+    def redmine_upload(file_path: str, description: str | None = None) -> str:
+        """Upload a file to Redmine and return the attachment token."""
 
-        response = request(f"attachments/download/{attachment_id}/{filename}", "get",
-                           content_type="application/octet-stream")
-        if response["status_code"] != 200 or not response["body"]:
-            return yd(response)
+        try:
+            path = pathlib.Path(file_path).expanduser()
+            assert path.is_absolute(), f"Path must be fully qualified, got: {file_path}"
+            assert path.exists(), f"File does not exist: {file_path}"
 
-        with open(path, 'wb') as f:
-            f.write(response["body"])
+            params = {"filename": path.name}
+            if description:
+                params["description"] = description
 
-        return yd({"status_code": 200, "body": {"saved_to": str(path), "filename": filename}, "error": ""})
-    except Exception as e:
-        return yd({"status_code": 0, "body": None, "error": f"{e.__class__.__name__}: {e}"})
+            with open(path, "rb") as f:
+                file_content = f.read()
 
-def main():
+            result = request(
+                settings,
+                path="uploads.json",
+                method="post",
+                params=params,
+                content_type="application/octet-stream",
+                content=file_content,
+            )
+            return yd(result)
+        except Exception as e:
+            return yd({"status_code": 0, "body": None, "error": f"{e.__class__.__name__}: {e}"})
+
+    @mcp.tool()
+    def redmine_download(
+        attachment_id: int,
+        save_path: str,
+        filename: str | None = None,
+    ) -> str:
+        """Download an attachment from Redmine and save it locally."""
+
+        try:
+            path = pathlib.Path(save_path).expanduser()
+            assert path.is_absolute(), f"Path must be fully qualified, got: {save_path}"
+            assert not path.is_dir(), f"Path can't be a directory, got: {save_path}"
+
+            resolved_filename = filename
+            if not resolved_filename:
+                attachment_response = request(settings, f"attachments/{attachment_id}.json", "get")
+                if attachment_response["status_code"] != 200:
+                    return yd(attachment_response)
+
+                resolved_filename = attachment_response["body"]["attachment"]["filename"]
+
+            response = request(
+                settings,
+                f"attachments/download/{attachment_id}/{resolved_filename}",
+                "get",
+                content_type="application/octet-stream",
+            )
+            if response["status_code"] != 200 or not response["body"]:
+                return yd(response)
+
+            with open(path, "wb") as f:
+                f.write(response["body"])
+
+            return yd(
+                {
+                    "status_code": 200,
+                    "body": {"saved_to": str(path), "filename": resolved_filename},
+                    "error": "",
+                }
+            )
+        except Exception as e:
+            return yd({"status_code": 0, "body": None, "error": f"{e.__class__.__name__}: {e}"})
+
+    return mcp
+
+
+def main() -> None:
     """Main entry point for the mcp-redmine package."""
-    port = int(os.environ.get("PORT", 8369))
+
+    settings = RedmineSettings.from_env()
+    mcp = create_server(settings)
     mcp.settings.host = "0.0.0.0"
-    mcp.settings.port = port
+    mcp.settings.port = settings.port
     mcp.run(transport="streamable-http")
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- refactor the Redmine MCP server to load configuration lazily, expose a `create_server` factory, and support optional auth settings without relying on module import side effects
- update tool registrations to capture runtime settings and preserve upload/download helpers under the new structure
- document how to start the server with the official `mcp` CLI alongside the existing uv and Docker options

## Testing
- uv run python -m compileall mcp_redmine

------
https://chatgpt.com/codex/tasks/task_e_68d7e9ef6f8483288b97109bbd0ef1a6